### PR TITLE
fix deprecation warning in v7.1

### DIFF
--- a/index.js
+++ b/index.js
@@ -285,7 +285,11 @@ Shop.prototype.showMenu = function (opts) {
 };
 
 Shop.prototype.save = function (key) {
-    fs.writeFile(this.files[key], JSON.stringify(this.state[key]));
+    fs.writeFile(
+        this.files[key], 
+        JSON.stringify(this.state[key]), 
+        function(){}
+    );
 };
 
 Shop.prototype._error = function (msg) {


### PR DESCRIPTION
Node v7.1 outputs the following warning if fs.writeFile is
called without a callback:

(node:29568) DeprecationWarning: Calling an asynchronous
function without callback is deprecated.

This PR adds a dummy callback and prevents the warning from
being printed (or thrown in the future).