### PR TITLE
Fixed the [DEP0013] deprecation warning

### DIFF
--- a/index.js
+++ b/index.js
@@ -285,7 +285,7 @@ Shop.prototype.showMenu = function (opts) {
 };
 
 Shop.prototype.save = function (key) {
-    fs.writeFile(this.files[key], JSON.stringify(this.state[key]));
+    fs.writeFile(this.files[key], JSON.stringify(this.state[key]), function() {});
 };
 
 Shop.prototype._error = function (msg) {


### PR DESCRIPTION
A [DEP0013] deprecation warning is caused by [following line](https://github.com/workshopper/adventure/blob/ca4564e52c670dae2df00e3c66bbfe1f28b5793b/index.js#L288):

```
    fs.writeFile(this.files[key], JSON.stringify(this.state[key]));
```

This will cause, for example in `browserify-adventure`, ugly deprecation warnings and completely ruin the user experience. This simple change will rectify this.

