### PR TITLE
fix ENOTCONN error in Node v10.1.0

### DIFF
--- a/lib/menu.js
+++ b/lib/menu.js
@@ -53,7 +53,7 @@ module.exports = function (opts) {
     menu.once('close', function () {
         process.stdin.setRawMode(false);
         if (opts.autoclose) {
-            process.stdin.end();
+            process.stdin.destroy();
         }
     });
     emitter.close = function () { menu.close() };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "adventure",
-  "version": "2.11.1",
+  "version": "2.11.2",
   "description": "quickly hack together a nodeschool adventure",
   "main": "index.js",
   "dependencies": {


### PR DESCRIPTION
Node v10.1.0 throws an error when process.stdin.end() is called.
This PR replaces process.stdin.end() with process.stdin.destroy() to fix the issue.

For more information about the bug, visit:
https://github.com/workshopper/stream-adventure/issues/213